### PR TITLE
Add Shadcn Space in UI Frameworks & Libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,16 @@ This curated list contains 430 awesome open-source projects with a total of 5M s
 	npm install @duik/it
 	```
 </details>
+<details><summary><b><a href="https://github.com/shadcnspace/shadcnspace">shadcnspace</a></b> (⭐ ~318 · 🍴 ~12) – Open-source UI blocks, templates, and components built around the shadcn/ui ecosystem for React. <code><a href="http://bit.ly/34MBwT8">MIT</a></code> </summary> 
+
+- [GitHub](https://github.com/shadcnspace/shadcnspace) (👨‍💻 ~X · 🔀 ~12 · 📋 ~0 · ⏱️ 31.01.2026):
+
+	```
+	git clone https://github.com/shadcnspace/shadcnspace
+	```
+- [Website](https://shadcnspace.com) – Browse components, blocks, templates, and docs.
+
+</details>
 <details><summary>Show 11 hidden projects...</summary>
 
 - <b><a href="https://github.com/elastic/eui">eui</a></b> (🥈38 ·  ⭐ 6K) - Elastic UI Framework. <code><a href="https://tldrlegal.com/search?q=ICU">❗️ICU</a></code>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
<!--- Use this section to describe your changes. We recommend only to add, update, or remove one project per pull request. If your PR adds a new project, just put the project name and a short description of the project here.-->

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Shadcn Space to the UI Frameworks & Libraries section to highlight its React UI blocks, templates, and components built around shadcn/ui. Includes GitHub link, website, and a git clone snippet for quick access.

<sup>Written for commit c41d2431418a5016a7011019f502cd76c21e246e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

